### PR TITLE
make the example code for EmptyReturn badder

### DIFF
--- a/lib/Perl/Critic/Policy/Freenode/EmptyReturn.pm
+++ b/lib/Perl/Critic/Policy/Freenode/EmptyReturn.pm
@@ -69,8 +69,8 @@ return the appropriate value explicitly.
   }
   my %stuff = (
     one => 1,
-    two => 2,
-    three => get_stuff(), # oops! function returns empty list if @things is empty
+    two => get_stuff(), # oops! function returns empty list if @things is empty
+    three => 3,
   );
 
 Empty returns are permitted by this policy if the subroutine contains no


### PR DESCRIPTION
get_stuff() did trigger a warning but it failed to cause any real damage.