### PR TITLE
Community::Prototypes can detect explicit :prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /blib/
 /.build/
 _build/
+_build_params
 cover_db/
 inc/
 Build

--- a/t/Community/Prototypes.run
+++ b/t/Community/Prototypes.run
@@ -64,3 +64,23 @@ sub foo () { ... }
 ## cut
 
 sub foo (&;@) { ... }
+
+## name ExplicitPrototypes
+## failures 0
+## cut
+
+sub foo : prototype($$) { ... }
+
+## name ExplicitPrototypesWithSig
+## failures 0
+## cut
+
+use experimental 'signatures';
+sub foo : prototype($$) { ... }
+
+## name MojoSignaturePrototypes
+## failures 0
+## cut
+
+use Mojo::Base -base, -signatures;
+sub bar : prototype($@) { ... }


### PR DESCRIPTION
Fix #44

When using function signatures, prototypes can be set using
the ': prototype'.
With this change we can now detect explicit usage of prototype.