### PR TITLE
substitute [Perl::Critic::Policy::Plicease::ProhibitArrayAssignAref] for [Perl::Critic::Policy::ValuesAndExpressions::ProhibitArrayAssignAref]

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -97,7 +97,7 @@ EOW
         "Perl::Critic" => "1.126",
         "Perl::Critic::Policy::Objects::ProhibitIndirectSyntax" => "1.126",
         "Perl::Critic::Policy::Subroutines::ProhibitAmpersandSigils" => "1.126",
-        "Perl::Critic::Policy::ValuesAndExpressions::ProhibitArrayAssignAref" => 90,
+        "Perl::Critic::Policy::Plicease::ProhibitArrayAssignAref" => '100.00',
         "Perl::Critic::Policy::Variables::ProhibitConditionalDeclarations" => "1.126",
         "Perl::Critic::Policy::Variables::ProhibitLoopOnHash" => "0.005",
         "Perl::Critic::Policy::Variables::RequireLexicalLoopIterators" => "1.126",

--- a/lib/Perl/Critic/Policy/Community/ArrayAssignAref.pm
+++ b/lib/Perl/Critic/Policy/Community/ArrayAssignAref.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 use Perl::Critic::Utils qw(:severities :classification :ppi);
-use parent 'Perl::Critic::Policy::ValuesAndExpressions::ProhibitArrayAssignAref';
+use parent 'Perl::Critic::Policy::Plicease::ProhibitArrayAssignAref';
 
 our $VERSION = 'v1.0.4';
 
@@ -29,7 +29,8 @@ brackets can be wrapped in parentheses for clarity.
  @array = [1, 2, 3];   # not ok
  @array = ([1, 2, 3]); # ok
 
-This policy is a subclass of the L<Perl::Critic::Pulp> policy
+This policy is a subclass of L<Perl::Critic::Policy::Plicease::ProhibitArrayAssignAref>,
+which is a fork of the L<Perl::Critic::Pulp> policy
 L<Perl::Critic::Policy::ValuesAndExpressions::ProhibitArrayAssignAref>, and
 performs the same function but in the C<community> theme.
 

--- a/prereqs.yml
+++ b/prereqs.yml
@@ -9,7 +9,7 @@ runtime:
     Perl::Critic: '1.126'
     Perl::Critic::Policy::Objects::ProhibitIndirectSyntax: '1.126'
     Perl::Critic::Policy::Subroutines::ProhibitAmpersandSigils: '1.126'
-    Perl::Critic::Policy::ValuesAndExpressions::ProhibitArrayAssignAref: '90'
+    Perl::Critic::Policy::Plicease::ProhibitArrayAssignAref: '100.00'
     Perl::Critic::Policy::Variables::ProhibitConditionalDeclarations: '1.126'
     Perl::Critic::Policy::Variables::ProhibitLoopOnHash: '0.005'
     Perl::Critic::Policy::Variables::RequireLexicalLoopIterators: '1.126'


### PR DESCRIPTION
Possible fix for #54 

This uses a fork of `[Perl::Critic::Policy::ValuesAndExpressions::ProhibitArrayAssignAref]`.  The changes made in the fork are minimal save for stripping out other Perl-Critic-Pulp policies and utilities.  (`List::MoreUtils` aren't even used by the one policy used by PCC).  I propose this a s a fix, rather than forking the policy into `Perl-Critic-Community` since Perl-Critic-Pulp is GPL3.